### PR TITLE
Changed Statistics component to display 'No feedback given' 

### DIFF
--- a/part1/unicafe/src/components/statistics/Statistics.jsx
+++ b/part1/unicafe/src/components/statistics/Statistics.jsx
@@ -12,11 +12,17 @@ const Statistics = ({ goodCount, neutralCount, badCount }) => {
   return (
     <div>
       <h1>Statistics</h1>
-      <p>Good {goodCount}</p>
-      <p>Neutral {neutralCount}</p>
-      <p>Bad {badCount}</p>
-      <p>Total {getTotalCount()}</p>
-      <p>Average {isNaN(getAverageScore()) ? 0 : getAverageScore()}</p>
+      {getTotalCount() > 0 ? (
+        <>
+          <p>Good {goodCount}</p>
+          <p>Neutral {neutralCount}</p>
+          <p>Bad {badCount}</p>
+          <p>Total {getTotalCount()}</p>
+          <p>Average {isNaN(getAverageScore()) ? 0 : getAverageScore()}</p>
+        </>
+      ) : (
+        <p>No feedback given</p>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
Statistics component now conditonally renders the feedback count if the total feedback count is greater than 0, else "No feedback given" message is rendered. 